### PR TITLE
Revert "Stop opening File Viewer when Workspace launches"

### DIFF
--- a/GWorkspace/FileViewer/GWViewersManager.m
+++ b/GWorkspace/FileViewer/GWViewersManager.m
@@ -142,7 +142,7 @@ static GWViewersManager *vwrsmanager = nil;
     }
   else
     {
-      //[self showRootViewer];
+      [self showRootViewer];
   }
 }
 


### PR DESCRIPTION
This reverts commit 0d278d41b6678ec08a7cde512f2e11c55c8eed27.

For non dbus menu setup Workspace menu will not appear until switching apps without this.  