### PR TITLE
Build on NetBSD and enable inotify based FSWatcher on FreeBSD

### DIFF
--- a/Tools/fswatcher/GNUmakefile.in
+++ b/Tools/fswatcher/GNUmakefile.in
@@ -12,6 +12,7 @@ WITH_FAM=@with_fam@
 
 ifeq ($(WITH_INOTIFY),yes)
   fswatcher_OBJC_FILES = fswatcher-inotify.m
+  fswatcher_TOOL_LIBS += @INOTIFY_LIBS@
 else
   ifeq ($(WITH_FAM),yes)
     fswatcher_OBJC_FILES = fswatcher-fam.m

--- a/Tools/fswatcher/GNUmakefile.in
+++ b/Tools/fswatcher/GNUmakefile.in
@@ -12,7 +12,6 @@ WITH_FAM=@with_fam@
 
 ifeq ($(WITH_INOTIFY),yes)
   fswatcher_OBJC_FILES = fswatcher-inotify.m
-  fswatcher_TOOL_LIBS += @INOTIFY_LIBS@
 else
   ifeq ($(WITH_FAM),yes)
     fswatcher_OBJC_FILES = fswatcher-fam.m

--- a/Tools/fswatcher/GNUmakefile.preamble
+++ b/Tools/fswatcher/GNUmakefile.preamble
@@ -26,3 +26,11 @@ ifneq ($(wildcard /usr/pkg/lib),)
   ADDITIONAL_LIB_DIRS += -L/usr/pkg/lib
 endif
 
+# Link against libinotify on systems that need it (NetBSD, older FreeBSD)
+# Linux and newer FreeBSD have inotify in libc
+ifeq ($(WITH_INOTIFY),yes)
+  ifneq ($(wildcard /usr/pkg/lib/libinotify.*),)
+    ADDITIONAL_TOOL_LIBS += -linotify
+  endif
+endif
+

--- a/Tools/fswatcher/GNUmakefile.preamble
+++ b/Tools/fswatcher/GNUmakefile.preamble
@@ -11,8 +11,18 @@ ADDITIONAL_CFLAGS += -Wall
 ADDITIONAL_INCLUDE_DIRS += -I../../DBKit
 ADDITIONAL_INCLUDE_DIRS += -I../../Workspace
 
+# Add pkgsrc paths for NetBSD/FreeBSD (inotify)
+ifneq ($(wildcard /usr/pkg/include),)
+  ADDITIONAL_INCLUDE_DIRS += -I/usr/pkg/include
+endif
+
 # Additional LDFLAGS to pass to the linker
 # ADDITIONAL_LDFLAGS += 
 
 ADDITIONAL_LIB_DIRS += -L../../DBKit/$(GNUSTEP_OBJ_DIR)
+
+# Add pkgsrc library paths for NetBSD/FreeBSD
+ifneq ($(wildcard /usr/pkg/lib),)
+  ADDITIONAL_LIB_DIRS += -L/usr/pkg/lib
+endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,17 @@ AC_DEFINE_UNQUOTED([GW_DEBUG_LOG], [$GW_DEBUG_LOG], [debug logging])
 # fswatcher-inotify - automatically detect and use when available
 #--------------------------------------------------------------------
 with_inotify=no
+INOTIFY_LIBS=""
+
 AC_CHECK_HEADERS([sys/inotify.h], [with_inotify=yes])
+
+# Check if we need to link against libinotify (NetBSD, FreeBSD)
+if test "x$with_inotify" = "xyes"; then
+  AC_CHECK_FUNC(inotify_init, [],
+    [AC_CHECK_LIB(inotify, inotify_init, 
+      [INOTIFY_LIBS="-linotify"],
+      [with_inotify=no])])
+fi
 
 # Allow manual override
 AC_ARG_WITH(inotify,
@@ -120,6 +130,7 @@ AC_ARG_WITH(inotify,
   [], [])
   
 AC_SUBST(with_inotify)
+AC_SUBST(INOTIFY_LIBS)
 
 AC_CONFIG_FILES([
   GNUmakefile


### PR DESCRIPTION
inotify based FSWatcher on FreeBSD tested on FreeBSD 15 (inotify was introduced in 15)