### PR TITLE
Fix swap16/32/64 macro clash on OpenBSD

### DIFF
--- a/DSStore/DSBuddyAllocator.m
+++ b/DSStore/DSBuddyAllocator.m
@@ -14,6 +14,12 @@
 #define BUDDY_HEADER_SIZE 32
 
 // Byte swapping functions
+// Undefine any system macros with these names before defining the local static
+// functions. On OpenBSD, <sys/endian.h> defines swap16/swap32/swap64 as macros,
+// which would otherwise break these definitions via macro expansion.
+#undef swap16
+#undef swap32
+#undef swap64
 static uint16_t swap16(uint16_t x) {
     return ((x & 0xFF00) >> 8) | ((x & 0x00FF) << 8);
 }

--- a/DSStore/DSStoreCodecs.m
+++ b/DSStore/DSStoreCodecs.m
@@ -7,6 +7,11 @@
 #import "DSStoreCodecs.h"
 
 // Byte swapping functions
+// Undefine any system macros with these names before defining the local static
+// functions. On OpenBSD, <sys/endian.h> defines swap32/swap64 as macros, which
+// would otherwise break these definitions via macro expansion.
+#undef swap32
+#undef swap64
 static uint32_t swap32(uint32_t x) {
     return ((x & 0xFF000000) >> 24) | ((x & 0x00FF0000) >> 8) |
            ((x & 0x0000FF00) << 8)  | ((x & 0x000000FF) << 24);


### PR DESCRIPTION
## Problem

On OpenBSD, `<sys/endian.h>` defines `swap16`, `swap32` and `swap64` as macros. These get pulled in transitively (via Foundation/system headers) and expand inside the local `static` byte-swap function definitions in `DSStore/DSBuddyAllocator.m` and `DSStore/DSStoreCodecs.m`, breaking compilation.

## Fix

`#undef swap16/swap32/swap64` immediately before the function definitions in each file.

This is a no-op on platforms that don't define these macros (undefining an undefined macro does nothing), so **Linux/FreeBSD builds are unchanged** — the existing FreeBSD/Arch/Debian CI here should stay green.

## Context

This replaces the out-of-tree patch currently carried in gershwin-developer (`Library/Patches/gershwin-workspace-dsbbuddy-swap.patch`, from gershwin-developer#33). Landing it here lets gershwin-developer drop that patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)