### PR TITLE
ci: add OpenBSD build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,3 +137,34 @@ jobs:
       - name: Build workspace
         working-directory: gershwin-developer
         run: make workspace
+
+  build-openbsd-78-amd64:
+    name: OpenBSD x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: gershwin-workspace
+
+      - name: Build workspace inside OpenBSD VM
+        uses: vmactions/openbsd-vm@v1
+        with:
+          release: "7.8"
+          usesh: true
+          sync: rsync
+          copyback: false
+          cpu: 2
+          mem: 4096
+          prepare: |
+            pkg_add -I git
+          run: |
+            set -e
+            BASE="$(pwd)"
+            git clone --depth 1 https://github.com/gershwin-desktop/gershwin-developer.git
+            cd "$BASE/gershwin-developer"
+            ./Library/Scripts/Bootstrap.sh
+            SKIP_REPOS="${{ env.SKIP_REPOS }}" ./Library/Scripts/Checkout.sh
+            ln -sfn "$BASE/gershwin-workspace" Library/Sources/gershwin-workspace
+            make corelibs
+            make workspace


### PR DESCRIPTION
## What

Adds an **OpenBSD 7.8** job to the workspace CI, mirroring the existing FreeBSD/Arch/Debian jobs: clone gershwin-developer → `Bootstrap` → `Checkout` (with `SKIP_REPOS`) → symlink this checkout into `Library/Sources/gershwin-workspace` → `make corelibs` → `make workspace`.

Uses `vmactions/openbsd-vm` (release 7.8). **Build + install only — no packaging**, same as the other jobs.

## Why now

gershwin-developer's OpenBSD support landed on `main` (Bootstrap/Functions OpenBSD branches, `/usr/X11R6` flags, `openpam`, the component fixes, etc.), so corelibs + workspace now build on OpenBSD.

Note: the OpenBSD job runs in an emulated VM and builds the full core-library stack, so expect it to take a while (timeout 240m), like the FreeBSD job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)