### PR TITLE
ci: verify PR branch source is built (debug)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,20 @@ jobs:
             ./Library/Scripts/Bootstrap.sh
             SKIP_REPOS="${{ env.SKIP_REPOS }}" ./Library/Scripts/Checkout.sh
             ln -sfn "$BASE/gershwin-workspace" Library/Sources/gershwin-workspace
+            echo "=== GitHub context ==="
+            echo "event_name = ${{ github.event_name }}"
+            echo "ref        = ${{ github.ref }}"
+            echo "sha        = ${{ github.sha }}"
+            echo "head_ref   = ${{ github.head_ref }}"
+            echo "base_ref   = ${{ github.base_ref }}"
+            echo "=== Symlink + marker (present only on the PR branch) ==="
+            ls -la Library/Sources/gershwin-workspace
+            if [ -f Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt ]; then
+              echo "MARKER FOUND -> building PR branch source"
+              cat Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt
+            else
+              echo "MARKER MISSING -> NOT building PR branch source (would be main)"
+            fi
             make corelibs
             make workspace
 
@@ -90,6 +104,29 @@ jobs:
       - name: Link workspace source under test
         working-directory: gershwin-developer
         run: ln -sfn "$GITHUB_WORKSPACE/gershwin-workspace" Library/Sources/gershwin-workspace
+
+      - name: "DEBUG: prove branch source under test"
+        working-directory: gershwin-developer
+        run: |
+          echo "=== GitHub context ==="
+          echo "event_name = ${{ github.event_name }}"
+          echo "ref        = ${{ github.ref }}"
+          echo "sha        = ${{ github.sha }}"
+          echo "head_ref   = ${{ github.head_ref }}"
+          echo "base_ref   = ${{ github.base_ref }}"
+          echo "=== Checked-out gershwin-workspace HEAD ==="
+          git -C "$GITHUB_WORKSPACE/gershwin-workspace" rev-parse HEAD || true
+          git -C "$GITHUB_WORKSPACE/gershwin-workspace" log -1 --oneline || true
+          echo "=== Symlink resolution ==="
+          ls -la Library/Sources/gershwin-workspace
+          readlink -f Library/Sources/gershwin-workspace || true
+          echo "=== Branch marker (present only on the PR branch) ==="
+          if [ -f Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt ]; then
+            echo "MARKER FOUND -> building PR branch source"
+            cat Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt
+          else
+            echo "MARKER MISSING -> NOT building PR branch source (would be main)"
+          fi
 
       - name: Build core libraries
         working-directory: gershwin-developer
@@ -130,6 +167,29 @@ jobs:
         working-directory: gershwin-developer
         run: ln -sfn "$GITHUB_WORKSPACE/gershwin-workspace" Library/Sources/gershwin-workspace
 
+      - name: "DEBUG: prove branch source under test"
+        working-directory: gershwin-developer
+        run: |
+          echo "=== GitHub context ==="
+          echo "event_name = ${{ github.event_name }}"
+          echo "ref        = ${{ github.ref }}"
+          echo "sha        = ${{ github.sha }}"
+          echo "head_ref   = ${{ github.head_ref }}"
+          echo "base_ref   = ${{ github.base_ref }}"
+          echo "=== Checked-out gershwin-workspace HEAD ==="
+          git -C "$GITHUB_WORKSPACE/gershwin-workspace" rev-parse HEAD || true
+          git -C "$GITHUB_WORKSPACE/gershwin-workspace" log -1 --oneline || true
+          echo "=== Symlink resolution ==="
+          ls -la Library/Sources/gershwin-workspace
+          readlink -f Library/Sources/gershwin-workspace || true
+          echo "=== Branch marker (present only on the PR branch) ==="
+          if [ -f Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt ]; then
+            echo "MARKER FOUND -> building PR branch source"
+            cat Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt
+          else
+            echo "MARKER MISSING -> NOT building PR branch source (would be main)"
+          fi
+
       - name: Build core libraries
         working-directory: gershwin-developer
         run: make corelibs
@@ -166,5 +226,19 @@ jobs:
             ./Library/Scripts/Bootstrap.sh
             SKIP_REPOS="${{ env.SKIP_REPOS }}" ./Library/Scripts/Checkout.sh
             ln -sfn "$BASE/gershwin-workspace" Library/Sources/gershwin-workspace
+            echo "=== GitHub context ==="
+            echo "event_name = ${{ github.event_name }}"
+            echo "ref        = ${{ github.ref }}"
+            echo "sha        = ${{ github.sha }}"
+            echo "head_ref   = ${{ github.head_ref }}"
+            echo "base_ref   = ${{ github.base_ref }}"
+            echo "=== Symlink + marker (present only on the PR branch) ==="
+            ls -la Library/Sources/gershwin-workspace
+            if [ -f Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt ]; then
+              echo "MARKER FOUND -> building PR branch source"
+              cat Library/Sources/gershwin-workspace/CI_BRANCH_MARKER.txt
+            else
+              echo "MARKER MISSING -> NOT building PR branch source (would be main)"
+            fi
             make corelibs
             make workspace

--- a/CI_BRANCH_MARKER.txt
+++ b/CI_BRANCH_MARKER.txt
@@ -1,0 +1,3 @@
+branch: ci/verify-branch-source
+purpose: Prove CI builds the PR branch's gershwin-workspace source, not main.
+This file does NOT exist on main. If CI debug output shows it, the branch source is in use.


### PR DESCRIPTION
## What

Adds debugging to the build workflow to **prove** that CI builds the PR branch's `gershwin-workspace` source and not `main`.

## How it proves it

- Adds `CI_BRANCH_MARKER.txt` — a file that exists **only on this branch**, not on `main`.
- Adds a debug step to every build job (FreeBSD, Arch, Debian, OpenBSD) that:
  - Prints the GitHub context (`event_name`, `ref`, `sha`, `head_ref`, `base_ref`).
  - For container jobs, prints the checked-out `gershwin-workspace` HEAD SHA + last commit.
  - Resolves the `Library/Sources/gershwin-workspace` symlink.
  - Checks for the marker:
    - **MARKER FOUND** → CI is building the PR branch source ✅
    - **MARKER MISSING** → CI is building `main` (the bug we'd be hunting) ❌

## Expected result

Because `SKIP_REPOS` includes `gershwin-workspace`, `Checkout.sh` does not clone it from GitHub; the workflow symlinks the checked-out PR branch instead. So every job should print **MARKER FOUND** and the PR branch's `head_ref`/SHA.

This is a temporary verification PR — revert the debug + marker once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)