### PR TITLE
Revert "Optimize Workspace startup time" — breaks desktop icons and the file-viewer close button

### DIFF
--- a/Workspace/Desktop/GWDesktopManager.m
+++ b/Workspace/Desktop/GWDesktopManager.m
@@ -203,13 +203,8 @@ static GWDesktopManager *desktopManager = nil;
       XCloseDisplay(display);
     }
   
-  // Show desktop window + dock immediately for perceived performance.
-  // Defer icon population to next runloop — each icon creates an X11 window
-  // (~50+ XCreateWindow calls) which blocks startup 1s+.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [desktopView showMountedVolumes];
-    [desktopView showContentsOfNode: dskNode];
-  });
+  [desktopView showMountedVolumes];
+  [desktopView showContentsOfNode: dskNode];
   [self addWatcherForPath: [dskNode path]];
     
   if ((hidedock == NO) && ([dock superview] == nil)) {

--- a/Workspace/Workspace.m
+++ b/Workspace/Workspace.m
@@ -848,30 +848,23 @@ NSString *_pendingSystemActionTitle = nil;
 
   }
 
-  // Defer non-essential GORM loads to next runloop for faster startup
-  dispatch_async(dispatch_get_main_queue(), ^{
-    prefController = [PrefController new];
-    if ([defaults boolForKey: @"uses_inspector"]) {
-      inspector = [Inspector new];
-      [self showInspector: nil];
-    }
-  });
-
-  // Lazy inspector — created on first showInspector: call if not already done
-  if ([defaults boolForKey: @"uses_inspector"] == NO) {
-    inspector = nil;
-  }
-
+  prefController = [PrefController new];  
+  
   history = [[History alloc] init];
-
+  
   openWithController = [[OpenWithController alloc] init];
   runExtController = [[RunExternalController alloc] init];
-
+  	    
   finder = [Finder finder];
-
+  
   vwrsManager = [GWViewersManager viewersManager];
   // Don't open viewer windows on startup - just show desktop
   // [vwrsManager showViewers];
+  
+  inspector = [Inspector new];
+  if ([defaults boolForKey: @"uses_inspector"]) {  
+    [self showInspector: nil]; 
+  }
   
   fileOpsManager = [Operation new];
   
@@ -3068,10 +3061,7 @@ NSString *_pendingSystemActionTitle = nil;
 
 - (void)showPreferences:(id)sender
 {
-  if (prefController == nil) {
-    prefController = [PrefController new];
-  }
-  [prefController activate];
+  [prefController activate]; 
 }
 
 - (void)activateContextHelp:(id)sender
@@ -3633,9 +3623,6 @@ NSString *_pendingSystemActionTitle = nil;
 
 - (void)showInspector:(id)sender
 {
-  if (inspector == nil) {
-    inspector = [Inspector new];
-  }
   [inspector activate];
   [inspector setCurrentSelection: selectedPaths];
 }

--- a/Workspace/main.m
+++ b/Workspace/main.m
@@ -102,9 +102,9 @@ static void killOtherInstances(const char *myBasename, pid_t myPid)
     closedir(procDir);
     
     if (killedCount > 0) {
-        fprintf(stderr, "Workspace: Terminated %d other instance(s), waiting 50ms for cleanup\n",
+        fprintf(stderr, "Workspace: Terminated %d other instance(s), waiting 500ms for cleanup\n", 
                 killedCount);
-        usleep(50000); // Wait 50ms for processes to terminate (SIGKILL is immediate)
+        usleep(500000); // Wait 500ms for processes to terminate
     } else {
         fprintf(stderr, "Workspace: No other instances found\n");
     }


### PR DESCRIPTION
This reverts commit 05a6657 ("Optimize Workspace startup time").

**Verified:** reverting this commit on a running NextBSD box restores all three regressions below — desktop icons repopulate, the System Disk icon returns, and file-viewer windows close from the title-bar button again.

## Time spent attributing this (~2.5–3.5 h)

| Phase | Rough effort |
|---|---|
| Reproduce + prove the app-side close path was fine (read source, style mask, `windowShouldClose`/`performClose`) | ~30 min |
| Install X11 tooling, connect to `:0`, prove `WM_DELETE_WINDOW` closes it, diff viewer vs Terminal at the X level | ~45 min |
| Read the window-manager close path (`gershwin-windowmanager`), find the framing inconsistency | ~30 min |
| Rebuild + swap the WM at a pre-batch commit to rule it out (Test A) | ~30–45 min (mostly build/restart) |
| Bisect Workspace to the two candidate commits + rebuild/confirm | ~30–45 min |
| Revert + write this PR | ~20 min |

## Cost / process note
Attributing #3 alone took a long manual session: reproducing it, instrumenting the X server (`xdotool`/`xprop`), proving the app-side close path was fine, diffing the viewer against a working Terminal at the X-protocol level, reading the WM close path, rebuilding/swapping the window manager to rule it out, then bisecting Workspace history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)