### PR TITLE
React instantly to changes in GSScaleFactor

### DIFF
--- a/Workspace/Desktop/Dock/Dock.m
+++ b/Workspace/Desktop/Dock/Dock.m
@@ -58,16 +58,6 @@ static inline CGFloat _dockScaleFactor(void)
   return (sf > 0.0) ? sf : 1.0;
 }
 
-/* Compute the cell (tile) dimension for a given icon size, scaled for HiDPI.
- * The base formula is ceil(iconSize / 3 * 4).  On HiDPI displays the cell
- * frame must be enlarged by GSScaleFactor so the dock occupies the correct
- * physical area.  The icon IMAGE size stays unscaled (the rendering pipeline
- * handles HiDPI). */
-static inline CGFloat _scaledCellSize(int iconSize)
-{
-  return ceil(iconSize / 3 * 4) * _dockScaleFactor();
-}
-
 /* small category to access NSNUmericSearch through a selector */
 
 @interface NSString (NumericSort)
@@ -755,22 +745,30 @@ static inline CGFloat _scaledCellSize(int iconSize)
   /* Use SCALED cell for the dock window frame (screen pixel coordinates). */
   CGFloat scaledCell = icnrect.size.width * sf;
 
-  rect.size.height = [icons count] * scaledCell;
-  if (targetIndex != -1) {
-    rect.size.height += scaledCell;
-  }
-
+  /* The dock fits on screen along the length of its bar: width for a bottom
+   * dock, height for a left/right dock.  Use the correct dimension so the
+   * fit loop does not shrink the icons of a bottom dock that is wide but
+   * only one cell tall. */
   maxheight -= (scaledCell * 2);
 
-  while (rect.size.height > maxheight) {
+  CGFloat barLength = [icons count] * scaledCell;
+  if (targetIndex != -1) {
+    barLength += scaledCell;
+  }
+
+  CGFloat maxBarLength = (position == DockPositionBottom)
+    ? scrrect.size.width
+    : maxheight;
+
+  while (barLength > maxBarLength) {
     iconSize -= ICN_INCR;
     icnrect.size.height = ceil(iconSize / 3 * 4);
     icnrect.size.width = icnrect.size.height;
     scaledCell = icnrect.size.width * sf;
-    rect.size.height = [icons count] * scaledCell;
+    barLength = [icons count] * scaledCell;
 
     if (targetIndex != -1) {
-      rect.size.height += scaledCell;
+      barLength += scaledCell;
     }
 
     if (iconSize <= MIN_ICN_SIZE) {

--- a/Workspace/Desktop/GWDesktopManager.m
+++ b/Workspace/Desktop/GWDesktopManager.m
@@ -491,10 +491,34 @@ static CGFloat lastScaleFactor = 1.0;
 
   /* The GNUstep backend may still convert GNUstep -> X11 coordinates with the
    * previous screen height right after a resolution change, misplacing the
-   * dock.  Re-tile once the backend has settled.  The Workspace's main run
-   * loop is frequently blocked in DO calls, so perform a delayed hop via a
-   * background thread instead of a run-loop timer. */
+   * dock and the desktop window.  Re-position once the backend has settled.
+   * The Workspace's main run loop is frequently blocked in DO calls, so
+   * perform a delayed hop via a background thread instead of a run-loop
+   * timer. */
   [self scheduleDockReTile];
+  [self scheduleDesktopWindowRePosition];
+}
+
+- (void)scheduleDesktopWindowRePosition
+{
+  [NSThread detachNewThreadSelector: @selector(desktopWindowRePositionThread:)
+                           toTarget: self
+                         withObject: nil];
+}
+
+- (void)desktopWindowRePositionThread:(id)arg
+{
+  CREATE_AUTORELEASE_POOL (pool);
+  [NSThread sleepForTimeInterval: 0.6];
+  [self performSelectorOnMainThread: @selector(desktopWindowRePositionOnMainThread)
+                        withObject: nil
+                     waitUntilDone: NO];
+  RELEASE (pool);
+}
+
+- (void)desktopWindowRePositionOnMainThread
+{
+  [win setFrame: [GWDesktopWindow desktopFullFrame] display: YES];
 }
 
 - (void)scheduleDockReTile

--- a/Workspace/Desktop/GWDesktopManager.m
+++ b/Workspace/Desktop/GWDesktopManager.m
@@ -45,6 +45,8 @@
 
 static GWDesktopManager *desktopManager = nil;
 
+static CGFloat lastScaleFactor = 1.0;
+
 @implementation GWDesktopManager
 
 + (GWDesktopManager *)desktopManager
@@ -93,6 +95,11 @@ static GWDesktopManager *desktopManager = nil;
 
     defaults = [NSUserDefaults standardUserDefaults];	
 
+    /* GNUstep loads the defaults lazily; synchronize up front so the first
+     * GSScaleFactor read (used when creating the desktop window below) sees
+     * the externally-written value instead of a stale one. */
+    [defaults synchronize];
+
     singleClickLaunch = [defaults boolForKey: @"singleclicklaunch"];
     defentry = [defaults objectForKey: @"dockposition"];
     dockPosition = defentry ? [defentry intValue] : DockPositionRight;
@@ -137,6 +144,19 @@ static GWDesktopManager *desktopManager = nil;
            selector: @selector(screenParametersDidChange:)
                name: NSApplicationDidChangeScreenParametersNotification
              object: nil];
+
+    /* React live to GSScaleFactor changes.  GNUstep only posts
+     * NSUserDefaultsDidChangeNotification for changes made in this process,
+     * so instead poll: synchronize re-reads external writes, then diff
+     * against the last seen value so unrelated changes are ignored. */
+    lastScaleFactor = [[NSUserDefaults standardUserDefaults] floatForKey: @"GSScaleFactor"];
+    if (lastScaleFactor == 0.0)
+      lastScaleFactor = 1.0;
+    [NSTimer scheduledTimerWithTimeInterval: 1.0
+                                     target: self
+                                   selector: @selector(checkScaleFactor:)
+                                   userInfo: nil
+                                    repeats: YES];
 
     [nc addObserver: self 
            selector: @selector(fileSystemWillChange:) 
@@ -420,6 +440,24 @@ static GWDesktopManager *desktopManager = nil;
 - (BOOL)dockActive
 {
   return !hidedock;
+}
+
+- (void)checkScaleFactor:(NSTimer *)timer
+{
+  /* GNUstep caches defaults per-process; synchronize re-reads the store so
+   * external writes (defaults tool, Display prefPane) become visible. */
+  [[NSUserDefaults standardUserDefaults] synchronize];
+
+  CGFloat factor = [[NSUserDefaults standardUserDefaults] floatForKey: @"GSScaleFactor"];
+  if (factor == 0.0)
+    factor = 1.0;
+
+  if (factor == lastScaleFactor)
+    return;
+
+  NSDebugLLog(@"gwspace", @"GSScaleFactor changed from %.3f to %.3f", lastScaleFactor, factor);
+  lastScaleFactor = factor;
+  [self screenParametersDidChange: nil];
 }
 
 - (void)screenParametersDidChange:(NSNotification *)notif

--- a/Workspace/Desktop/GWDesktopManager.m
+++ b/Workspace/Desktop/GWDesktopManager.m
@@ -488,6 +488,37 @@ static CGFloat lastScaleFactor = 1.0;
   if (dock && hidedock == NO) {
     [dock tile];
   }
+
+  /* The GNUstep backend may still convert GNUstep -> X11 coordinates with the
+   * previous screen height right after a resolution change, misplacing the
+   * dock.  Re-tile once the backend has settled.  The Workspace's main run
+   * loop is frequently blocked in DO calls, so perform a delayed hop via a
+   * background thread instead of a run-loop timer. */
+  [self scheduleDockReTile];
+}
+
+- (void)scheduleDockReTile
+{
+  [NSThread detachNewThreadSelector: @selector(dockReTileThread:)
+                           toTarget: self
+                         withObject: nil];
+}
+
+- (void)dockReTileThread:(id)arg
+{
+  CREATE_AUTORELEASE_POOL (pool);
+  [NSThread sleepForTimeInterval: 0.6];
+  [self performSelectorOnMainThread: @selector(dockReTileOnMainThread)
+                        withObject: nil
+                     waitUntilDone: NO];
+  RELEASE (pool);
+}
+
+- (void)dockReTileOnMainThread
+{
+  if (dock && hidedock == NO) {
+    [dock tile];
+  }
 }
 
 - (void)setReservedFrames

--- a/Workspace/Desktop/GWDesktopView.m
+++ b/Workspace/Desktop/GWDesktopView.m
@@ -64,8 +64,8 @@
 
 #define DEF_COLOR [NSColor colorWithCalibratedRed: 0.39 green: 0.51 blue: 0.57 alpha: 1.00]
 
-/* Current GSScaleFactor (1.0 when unset).  Used to keep the desktop picture
- * at a constant physical size independent of the scale factor. */
+/* Current GSScaleFactor (1.0 when unset).  The desktop icon grid grows and
+ * shrinks with it so icons keep a consistent, non-overlapping layout. */
 static CGFloat desktopScaleFactor(void)
 {
   CGFloat factor = 1.0;
@@ -77,6 +77,20 @@ static CGFloat desktopScaleFactor(void)
 
 
 @implementation GWDesktopView
+
+- (void)calculateGridSize
+{
+  [super calculateGridSize];
+
+  /* Scale the cell size with GSScaleFactor so icons (which render at
+   * iconSize * sf via the image compositing path) keep their grid spacing. */
+  CGFloat factor = desktopScaleFactor();
+  if (factor != 1.0)
+    {
+      gridSize.width *= factor;
+      gridSize.height *= factor;
+    }
+}
 
 - (void)dealloc
 {
@@ -101,20 +115,13 @@ static CGFloat desktopScaleFactor(void)
 
       manager = mngr;
 
-      // Span the full virtual desktop (union of all screens), divided by
-      // GSScaleFactor so the desktop keeps a constant physical size
-      // independent of the scale factor.
+      // Span the full virtual desktop (union of all screens) in physical
+      // pixels.  View drawing is 1:1, so the wallpaper and icon grid fill the
+      // whole screen at every scale factor.
       NSArray *screens = [NSScreen screens];
       screenFrame = [[screens objectAtIndex:0] frame];
       for (NSUInteger si = 1; si < [screens count]; si++) {
         screenFrame = NSUnionRect(screenFrame, [[screens objectAtIndex:si] frame]);
-      }
-      {
-        CGFloat factor = desktopScaleFactor();
-        screenFrame.origin.x /= factor;
-        screenFrame.origin.y /= factor;
-        screenFrame.size.width /= factor;
-        screenFrame.size.height /= factor;
       }
       [self setFrame: screenFrame];
 
@@ -155,9 +162,50 @@ static CGFloat desktopScaleFactor(void)
 
       [self getDesktopInfo];
       dragIcon = nil;
+
+      /* Render labels at labelTextSize * GSScaleFactor so text grows with the
+       * scale factor like the icon grid.  Layout (calculateGridSize) keeps the
+       * base font and scales via the grid override, so sizes stay consistent. */
+      [self applyScaledLabelFont];
+      [self applyScaledIconSize];
     }
 
   return self;
+}
+
+- (void)applyScaledIconSize
+{
+  CGFloat factor = desktopScaleFactor();
+  if (factor == 1.0)
+    return;
+
+  int scaled = (int)(iconSize * factor);
+  NSUInteger i;
+  for (i = 0; i < [icons count]; i++)
+    {
+      [[icons objectAtIndex: i] setIconSize: scaled];
+    }
+}
+
+- (void)applyScaledLabelFont
+{
+  CGFloat factor = desktopScaleFactor();
+  if (factor == 1.0)
+    return;
+
+  NSFont *scaledFont = [NSFont systemFontOfSize: (int)(labelTextSize * factor)];
+  NSUInteger i;
+  for (i = 0; i < [icons count]; i++)
+    {
+      [[icons objectAtIndex: i] setFont: scaledFont];
+    }
+  [nameEditor setFont: scaledFont];
+}
+
+- (void)setLabelTextSize:(int)size
+{
+  [super setLabelTextSize: size];
+  [self applyScaledLabelFont];
 }
 
 - (void)newVolumeMountedAtPath:(NSString *)vpath
@@ -673,16 +721,14 @@ static CGFloat desktopScaleFactor(void)
 
   /* The content view's origin in window coordinates is always (0,0);
    * only the size changes when the screen configuration changes. */
-  {
-    CGFloat factor = desktopScaleFactor();
-    screenFrame.origin.x /= factor;
-    screenFrame.origin.y /= factor;
-    screenFrame.size.width /= factor;
-    screenFrame.size.height /= factor;
-  }
   [self setFrame: NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height)];
   _gridCached = NO;
-  [self tile];
+
+  /* Re-run "Clean Up" so icons re-flow into the grid and never land outside
+   * the visible space when the screen resolution or scale factor changes. */
+  [self cleanupIconPositions];
+  [self applyScaledLabelFont];
+  [self applyScaledIconSize];
   [self setNeedsDisplay: YES];
 }
 
@@ -943,6 +989,7 @@ static CGFloat desktopScaleFactor(void)
   BOOL changed = (size != iconSize);
 
   [super setIconSize: size];
+  [self applyScaledIconSize];
 
   /* Only rewrite ~/Desktop/.DS_Store (and fire the directory watcher) on a
    * real change — a same-value re-apply would trigger a needless refresh. */
@@ -1363,15 +1410,7 @@ static void GWHighlightFrameRect(NSRect aRect)
         {
           NSRect monFrame = [[screens objectAtIndex:si] frame];
           // Convert from screen coordinates to view-local coordinates
-          // (screenFrame.origin is the view's origin in screen coords),
-          // divided by GSScaleFactor like screenFrame above.
-          {
-            CGFloat factor = desktopScaleFactor();
-            monFrame.origin.x /= factor;
-            monFrame.origin.y /= factor;
-            monFrame.size.width /= factor;
-            monFrame.size.height /= factor;
-          }
+          // (screenFrame.origin is the view's origin in screen coords)
           NSRect localRect = NSMakeRect(monFrame.origin.x - screenFrame.origin.x,
                                         monFrame.origin.y - screenFrame.origin.y,
                                         monFrame.size.width,

--- a/Workspace/Desktop/GWDesktopView.m
+++ b/Workspace/Desktop/GWDesktopView.m
@@ -175,10 +175,10 @@ static CGFloat desktopScaleFactor(void)
 
 - (void)applyScaledIconSize
 {
+  /* Apply iconSize * factor to every icon.  When factor is 1.0 (or unset),
+   * reset back to the base iconSize so shrinking the scale factor restores
+   * the original size instead of leaving icons enlarged. */
   CGFloat factor = desktopScaleFactor();
-  if (factor == 1.0)
-    return;
-
   int scaled = (int)(iconSize * factor);
   NSUInteger i;
   for (i = 0; i < [icons count]; i++)
@@ -189,10 +189,9 @@ static CGFloat desktopScaleFactor(void)
 
 - (void)applyScaledLabelFont
 {
+  /* Apply labelTextSize * factor to every icon label.  When factor is 1.0
+   * (or unset), reset back to the base labelTextSize. */
   CGFloat factor = desktopScaleFactor();
-  if (factor == 1.0)
-    return;
-
   NSFont *scaledFont = [NSFont systemFontOfSize: (int)(labelTextSize * factor)];
   NSUInteger i;
   for (i = 0; i < [icons count]; i++)
@@ -1735,6 +1734,12 @@ static void GWHighlightFrameRect(NSRect aRect)
   [self tile];
   [self setNeedsDisplay: YES];
 
+  /* Desktop icons are created here directly (not via addRepForSubnode:), so
+   * apply GSScaleFactor to the newly loaded icons — otherwise a scale factor
+   * already set at launch leaves them at their unscaled size. */
+  [self applyScaledIconSize];
+  [self applyScaledLabelFont];
+
   if ([[NSUserDefaults standardUserDefaults] boolForKey: @"use_thumbnails"])
     {
       Thumbnailer *t = [Thumbnailer sharedThumbnailer];
@@ -2233,6 +2238,12 @@ static void GWHighlightFrameRect(NSRect aRect)
   [self addSubview: icon];
   RELEASE (icon);
   RELEASE (arp);
+
+  /* Apply GSScaleFactor to the newly added icon so desktop icons created
+   * after startup (or on launch with a scale factor already set) match the
+   * scaled size of icons created by applyScaledIconSize. */
+  [self applyScaledIconSize];
+  [self applyScaledLabelFont];
 
   return icon;
 }

--- a/Workspace/Desktop/GWDesktopWindow.m
+++ b/Workspace/Desktop/GWDesktopWindow.m
@@ -35,25 +35,14 @@
 
 + (NSRect)desktopFullFrame
 {
-  /* Union of all screen frames; width and height are divided by
-   * GSScaleFactor (like the menu bar does in Menu.app) so the desktop
-   * window keeps a constant physical size independent of the scale
-   * factor. */
+  /* Union of all screen frames in physical (device) pixels.  Used when the
+   * window is repositioned with setFrame: (which is applied 1:1), so the
+   * desktop always covers every monitor. */
   NSArray *screens = [NSScreen screens];
   NSRect fullFrame = [[screens objectAtIndex:0] frame];
   for (NSUInteger i = 1; i < [screens count]; i++) {
     fullFrame = NSUnionRect(fullFrame, [[screens objectAtIndex:i] frame]);
   }
-
-  CGFloat factor = 1.0;
-  id val = [[NSUserDefaults standardUserDefaults] objectForKey: @"GSScaleFactor"];
-  if (val)
-    factor = [val floatValue];
-  if (factor != 1.0)
-    {
-      fullFrame.size.width /= factor;
-      fullFrame.size.height /= factor;
-    }
 
   return fullFrame;
 }
@@ -65,11 +54,13 @@
 
 - (id)init
 {
-  // Compute the union of all screen frames so the desktop covers every monitor
+  /* NSUnscaledWindowMask keeps the window's user space identical to its
+   * device pixels, so the desktop is always the full physical screen and the
+   * (undivided) desktop view and its icons are never scaled or clipped. */
   NSRect fullFrame = [GWDesktopWindow desktopFullFrame];
 
   self = [super initWithContentRect: fullFrame
-                          styleMask: NSBorderlessWindowMask
+                          styleMask: NSBorderlessWindowMask | NSUnscaledWindowMask
 			    backing: NSBackingStoreBuffered
                               defer: NO];
   if (self)


### PR DESCRIPTION
**Don't merge as-is**, it halfway works but I am not yet happy with it.

@pkgdemon this is my attempt to react instantly to changes in GSScaleFactor, however

* I think it is too convoluted. There must be a simpler way to keep the desktop window size unaffected by GSScaleFactor changes and still have its content automatically scaled, like the icon view in normal windows (which just works)
* I think it breaks the icon scaling in Dock (icons don't grow in size enough)

Maybe you'd like to have a look at it?